### PR TITLE
fix docker-compose: restart coordinatord on failure

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     container_name: coordinatord
     depends_on:
       - coordinator_db
+    restart: on-failure
     build:
       context: ../
       dockerfile: Dockerfile


### PR DESCRIPTION
Coordinatord docker crashed because the coordinator_db
database docker was not ready early enough.
With this simple fix, the coordinatord is restarted