### PR TITLE
Coordinator broadcasts spend transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "base64-compat"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a8d4d2746f89841e49230dd26917df1876050f95abafafbe34f47cb534b88d7"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "bech32"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +351,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
+name = "jsonrpc"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8423b78fc94d12ef1a4a9d13c348c9a78766dda0cc18817adf0faf77e670c8"
+dependencies = [
+ "base64-compat",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +675,7 @@ dependencies = [
  "daemonize-simple",
  "dirs",
  "fern",
+ "jsonrpc",
  "log",
  "revault_net",
  "revault_tx 0.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ chrono = "0.4"
 # Used for storing the signatures and spend transactions
 tokio-postgres = "0.7"
 
+# To talk to bitcoind
+jsonrpc = "0.12"
+
 [dev-dependencies]
 revault_tx = { version = "0.3", features = ["use-serde"] }
 

--- a/src/bitcoind.rs
+++ b/src/bitcoind.rs
@@ -1,0 +1,191 @@
+use crate::config::BitcoindConfig;
+use jsonrpc::{
+    arg,
+    client::Client,
+    error::Error,
+    simple_http::{Error as HttpError, SimpleHttpTransport},
+};
+use revault_net::bitcoin::{consensus::encode, Transaction};
+use serde_json::Value as Json;
+use std::any::Any;
+use std::{fmt, fs};
+use tokio::time::{Duration, Instant};
+
+macro_rules! params {
+    ($($param:expr),* $(,)?) => {
+        [
+            $(
+                arg($param),
+            )*
+        ]
+    };
+}
+
+// If bitcoind takes more than 1 minute to answer one of our queries, fail.
+const RPC_SOCKET_TIMEOUT: u64 = 60;
+
+#[derive(Debug)]
+pub enum BitcoindError {
+    /// It can be related to us..
+    CookieFile(std::io::Error),
+    /// Or directly to bitcoind's RPC server
+    Server(Error),
+    BatchMissingResponse,
+}
+
+impl fmt::Display for BitcoindError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::CookieFile(e) => write!(f, "While reading the cookie file: {}", e),
+            Self::Server(e) => write!(f, "RPC server error: {}", e),
+            Self::BatchMissingResponse => write!(f, "Batch is missing a response"),
+        }
+    }
+}
+
+impl std::error::Error for BitcoindError {}
+
+impl From<HttpError> for BitcoindError {
+    fn from(e: HttpError) -> Self {
+        Self::Server(Error::Transport(Box::new(e)))
+    }
+}
+
+pub struct BitcoinD {
+    node_client: Client,
+    pub broadcast_interval: Duration,
+}
+
+impl BitcoinD {
+    pub async fn new(config: &BitcoindConfig) -> Result<BitcoinD, BitcoindError> {
+        let cookie_string =
+            fs::read_to_string(&config.cookie_path).map_err(|e| BitcoindError::CookieFile(e))?;
+
+        let node_client = Client::with_transport(
+            SimpleHttpTransport::builder()
+                .url(&config.addr.to_string())
+                .map_err(BitcoindError::from)?
+                .timeout(Duration::from_secs(RPC_SOCKET_TIMEOUT))
+                .cookie_auth(cookie_string)
+                .build(),
+        );
+
+        Ok(BitcoinD {
+            node_client,
+            broadcast_interval: config.broadcast_interval,
+        })
+    }
+
+    // Reasonably try to be robust to possible spurious communication error.
+    fn handle_error(&self, e: jsonrpc::Error, start: Instant) -> Result<(), BitcoindError> {
+        let now = Instant::now();
+
+        match e {
+            jsonrpc::Error::Transport(ref err) => {
+                log::error!("Transport error when talking to bitcoind: '{}'", err);
+
+                // This is *always* a HttpError. Rule out the error that can
+                // not occur after startup (ie if we encounter them it must be startup
+                // and we better be failing quickly).
+                let any_err = err as &dyn Any;
+                if let Some(http_err) = any_err.downcast_ref::<HttpError>() {
+                    match http_err {
+                        HttpError::InvalidUrl { .. } => return Err(BitcoindError::Server(e)),
+                        // FIXME: allow it to be unreachable for a handful of seconds,
+                        // but not at startup!
+                        HttpError::SocketError(_) => return Err(BitcoindError::Server(e)),
+                        HttpError::HttpParseError => {
+                            // Weird. Try again once, just in case.
+                            if now.duration_since(start) > Duration::from_secs(1) {
+                                return Err(BitcoindError::Server(e));
+                            }
+                            std::thread::sleep(Duration::from_secs(1));
+                        }
+                        _ => {}
+                    }
+                }
+
+                // This one *may* happen. For a number of reasons, the obvious one may
+                // be the RPC work queue being exceeded. In this case, and since we'll
+                // usually fail if we err try again for a reasonable amount of time.
+                if now.duration_since(start) > Duration::from_secs(45) {
+                    return Err(BitcoindError::Server(e));
+                }
+                std::thread::sleep(Duration::from_secs(1));
+                log::debug!("Retrying RPC request to bitcoind.");
+            }
+            jsonrpc::Error::Json(ref err) => {
+                // Weird. A JSON serialization error? Just try again but
+                // fail fast anyways as it should not happen.
+                log::error!(
+                    "JSON serialization error when talking to bitcoind: '{}'",
+                    err
+                );
+                if now.duration_since(start) > Duration::from_secs(1) {
+                    return Err(BitcoindError::Server(e));
+                }
+                std::thread::sleep(Duration::from_millis(500));
+                log::debug!("Retrying RPC request to bitcoind.");
+            }
+            _ => return Err(BitcoindError::Server(e)),
+        };
+
+        Ok(())
+    }
+
+    fn make_requests(
+        &self,
+        reqs: &[jsonrpc::Request],
+    ) -> Result<Vec<Result<Json, BitcoindError>>, BitcoindError> {
+        log::debug!("Sending to bitcoind: {:#?}", reqs);
+
+        // Trying to be robust on bitcoind's spurious failures. We try to support bitcoind failing
+        // under our feet for a few dozens of seconds, while not delaying an early failure (for
+        // example, if we got the RPC listening address or path to the cookie wrong).
+        let start = Instant::now();
+        loop {
+            match self.node_client.send_batch(reqs) {
+                Ok(resp) => {
+                    log::debug!("Got from bitcoind: {:#?}", resp);
+                    let res = resp
+                        .into_iter()
+                        .flatten()
+                        .map(|resp| resp.result().map_err(BitcoindError::Server))
+                        .collect::<Vec<Result<Json, BitcoindError>>>();
+
+                    // FIXME: why is rust-jsonrpc even returning a Vec of Option in the first
+                    // place??
+                    if res.len() != reqs.len() {
+                        return Err(BitcoindError::BatchMissingResponse);
+                    }
+
+                    return Ok(res);
+                }
+                Err(e) => {
+                    // Decide wether we should error, or not yet
+                    self.handle_error(e, start)?;
+                }
+            }
+        }
+    }
+
+    /// Broadcast a batch of transactions with 'sendrawtransaction'
+    pub fn broadcast_transactions(
+        &self,
+        txs: &[Transaction],
+    ) -> Result<Vec<Result<Json, BitcoindError>>, BitcoindError> {
+        let txs_hex: Vec<[Box<serde_json::value::RawValue>; 1]> = txs
+            .iter()
+            .map(|tx| params!(Json::String(encode::serialize_hex(tx))))
+            .collect();
+        log::debug!("Batch-broadcasting {:?}", txs_hex);
+        let reqs: Vec<jsonrpc::Request> = txs_hex
+            .iter()
+            .map(|hex| {
+                self.node_client
+                    .build_request("sendrawtransaction", hex.as_ref())
+            })
+            .collect();
+        self.make_requests(&reqs)
+    }
+}

--- a/src/coordinatord.rs
+++ b/src/coordinatord.rs
@@ -1,4 +1,4 @@
-use crate::config::{datadir_path, Config, ConfigError};
+use crate::config::{datadir_path, BitcoindConfig, Config, ConfigError};
 use revault_net::noise::PublicKey as NoisePubKey;
 
 use std::{fs, net::SocketAddr, os::unix::fs::DirBuilderExt, path::PathBuf, str::FromStr};
@@ -16,6 +16,8 @@ pub struct CoordinatorD {
 
     // For storing the signatures and spend transactions
     pub postgres_config: tokio_postgres::Config,
+
+    pub bitcoind_config: BitcoindConfig,
 }
 
 fn create_datadir(datadir_path: &PathBuf) -> Result<(), std::io::Error> {
@@ -57,6 +59,7 @@ impl CoordinatorD {
             daemon,
             listen,
             postgres_config,
+            bitcoind_config: config.bitcoind_config,
         })
     }
 

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -12,7 +12,8 @@ CREATE TABLE IF NOT EXISTS signatures (
 
 CREATE TABLE IF NOT EXISTS spend_txs (
     txid BYTEA UNIQUE NOT NULL,
-    transaction BYTEA NOT NULL
+    transaction BYTEA NOT NULL,
+    broadcasted BOOLEAN NOT NULL DEFAULT FALSE
 );
 
 CREATE TABLE IF NOT EXISTS spend_outpoints (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
+pub mod bitcoind;
 pub mod config;
 pub mod coordinatord;
 pub mod db;
 pub mod processing;
+pub mod spend_broadcaster;
 
 #[cfg(feature = "fuzztesting")]
 pub mod fuzz;

--- a/src/spend_broadcaster.rs
+++ b/src/spend_broadcaster.rs
@@ -1,0 +1,43 @@
+use crate::{
+    bitcoind::{BitcoinD, BitcoindError},
+    db::{fetch_spend_txs_to_broadcast, mark_broadcasted_spend},
+};
+use jsonrpc::error::{Error, RpcError};
+use std::sync::Arc;
+
+pub async fn spend_broadcaster(
+    bitcoind: BitcoinD,
+    config: Arc<tokio_postgres::Config>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut interval = tokio::time::interval(bitcoind.broadcast_interval);
+    loop {
+        interval.tick().await;
+        log::debug!("Trying to broadcast spend txs...");
+        let spend_txs = match fetch_spend_txs_to_broadcast(&config).await {
+            Ok(s) => s,
+            Err(e) => {
+                log::error!("Error while fetching txs: {}", e);
+                continue;
+            }
+        };
+        if spend_txs.is_empty() {
+            log::debug!("No spend txs in the database");
+            continue;
+        }
+        let results = bitcoind.broadcast_transactions(&spend_txs)?;
+        for (result, spend_tx) in results.into_iter().zip(spend_txs) {
+            match result {
+                Ok(_) | Err(BitcoindError::Server(Error::Rpc(RpcError { code: -27, .. }))) => {
+                    // Either it's all good or the tx is already in blockchain,
+                    // we mark it as broadcasted and be done
+                    mark_broadcasted_spend(&config, &spend_tx.txid()).await?;
+                    log::info!("Spend tx '{}' is broadcasted", spend_tx.txid());
+                }
+                Err(e) => {
+                    log::debug!("Error while broadcasting spend {:?}: {}", spend_tx, e);
+                }
+            }
+        }
+        log::debug!("Broadcast completed");
+    }
+}


### PR DESCRIPTION
The coordiantor tries to broadcast all the spends we know of every
N seconds (N is configurable, defaults to 300). The code that connects
to bitcoind is adapted from revaultd.