### PR TITLE
Separate connection listening and request processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,8 +689,7 @@ dependencies = [
 [[package]]
 name = "revault_net"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b575bcdb8edf9f5b45c051a8273c17472283a82bdcaea4b95a779dc63ccd0f"
+source = "git+https://github.com/revault/revault_net?branch=master#4f8a38606d93a2c8277a5ba021ea41882f0b0a16"
 dependencies = [
  "bitcoin",
  "log",
@@ -716,8 +715,7 @@ dependencies = [
 [[package]]
 name = "revault_tx"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ba676f3936696e931380bce36e567e16aab4f433cfe0e39830dcbe527669ec"
+source = "git+https://github.com/revault/revault_tx#f2735d85c084b36c20bfc8cf91d47163bda59bdf"
 dependencies = [
  "base64",
  "bitcoinconsensus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Antoine Poinsot <darosior@protonmail.com>"]
 edition = "2018"
 
 [dependencies]
-revault_net = "0.2.1"
+revault_net = { git = "https://github.com/revault/revault_net", branch = "master" }
 
 tokio = { version = "1.0", features = ["io-util",  "macros", "net", "rt-multi-thread"] }
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -9,7 +9,7 @@ description = "Honggfuzz based fuzzing for the Coordinator Server"
 [dependencies]
 honggfuzz = "0.5"
 revault_coordinatord = { path = "..", features = ["fuzztesting"] }
-revault_net = "0.2.1"
+revault_net = { git = "https://github.com/revault/revault_net", branch = "master" }
 revault_tx = { version = "0.4.1", features = ["use-serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"

--- a/src/coordinatord.rs
+++ b/src/coordinatord.rs
@@ -83,4 +83,13 @@ impl CoordinatorD {
     pub fn secret_file(&self) -> PathBuf {
         self.file_from_datadir("noise_secret")
     }
+
+    pub fn client_pubkeys(&self) -> Vec<NoisePubKey> {
+        self.managers_keys
+            .clone()
+            .into_iter()
+            .chain(self.stakeholders_keys.clone().into_iter())
+            .chain(self.watchtowers_keys.clone().into_iter())
+            .collect()
+    }
 }

--- a/src/spend_broadcaster.rs
+++ b/src/spend_broadcaster.rs
@@ -3,11 +3,10 @@ use crate::{
     db::{fetch_spend_txs_to_broadcast, mark_broadcasted_spend},
 };
 use jsonrpc::error::{Error, RpcError};
-use std::sync::Arc;
 
 pub async fn spend_broadcaster(
     bitcoind: BitcoinD,
-    config: Arc<tokio_postgres::Config>,
+    config: &tokio_postgres::Config,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut interval = tokio::time::interval(bitcoind.broadcast_interval);
     loop {


### PR DESCRIPTION
Each time a new connection is incoming, runtime start
a new thread for the noise protocole and the request processing
to handle it without blocking the tcp listener to listen
new incoming connection.